### PR TITLE
COMP: Use single export() call to fix namespace corruption

### DIFF
--- a/CMake/GenerateCMakeExports.cmake
+++ b/CMake/GenerateCMakeExports.cmake
@@ -14,19 +14,22 @@
 # DCMTKConfigVersion.cmake provides checking of DCMTK version compatibility
 # DCMTKConfig.cmake will contain options used to build this DCMTK package
 
-# Start with clean DCMTKTargets.cmake and fill it by appending
-file(WRITE "${CMAKE_BINARY_DIR}/DCMTKTargets.cmake" "")
-
-# Get and store all executable targets to DCMTKTargets.cmake within build's main dir
+# Get all targets to export into a single list so that export() runs without
+# APPEND. A single non-APPEND call allows CMake to resolve dependency targets
+# that live in other export sets (e.g. ITK codec targets) using those sets'
+# own namespaces, rather than blindly prepending the DCMTK:: namespace.
 get_property(DCMTK_EXECUTABLE_TARGETS GLOBAL PROPERTY DCMTK_EXECUTABLE_TARGETS)
-export(TARGETS ${DCMTK_EXECUTABLE_TARGETS} APPEND FILE "${CMAKE_BINARY_DIR}/DCMTKTargets.cmake" NAMESPACE DCMTK::)
-
-# Get and store libraries to DCMTKTargets.cmake within the build's main dir
 get_property(DCMTK_LIBRARY_TARGETS GLOBAL PROPERTY DCMTK_LIBRARY_TARGETS)
-export(TARGETS config ${DCMTK_LIBRARY_TARGETS} APPEND FILE "${CMAKE_BINARY_DIR}/DCMTKTargets.cmake" NAMESPACE DCMTK::)
-
-# Add interface library for conveniently linking to all libraries via DCMTK::DCMTK
-export(TARGETS DCMTK APPEND FILE "${CMAKE_BINARY_DIR}/DCMTKTargets.cmake" NAMESPACE DCMTK::)
+set(_dcmtk_all_export_targets
+    config
+    ${DCMTK_LIBRARY_TARGETS}
+    DCMTK
+    ${DCMTK_EXECUTABLE_TARGETS}
+)
+export(TARGETS ${_dcmtk_all_export_targets}
+    FILE "${CMAKE_BINARY_DIR}/DCMTKTargets.cmake"
+    NAMESPACE DCMTK::)
+unset(_dcmtk_all_export_targets)
 
 # Create DCMTKConfigVersion.cmake with basic DCMTK version information (build tree)
 set(DCMTK_CONFIG_VERSION "${CMAKE_BINARY_DIR}/DCMTKConfigVersion.cmake")


### PR DESCRIPTION
Replacing the three `APPEND` `export()` calls with a single non-`APPEND` call fixes a namespace corruption bug in `DCMTKTargets.cmake`.

<details>
<summary>Root cause</summary>

CMake's `cmExportBuildFileGenerator::HandleMissingTarget` has two code paths for dependency targets not in the current export set:

- **Non-append mode:** calls `FindExportInfo()`, which searches all registered build export sets. If the dependency is found in exactly one other set with one namespace, that namespace is used — e.g. `ITK::ITKZLIBModule`.
- **Append mode (`APPEND`):** skips the lookup and blindly prepends the current export's namespace, producing `DCMTK::ITK::ITKZLIBModule`.

The previous `file(WRITE) + 3×export(APPEND)` pattern was used only to accumulate targets across multiple calls. All three calls share the same `NAMESPACE DCMTK::`, so combining them into a single `export()` is equivalent — and avoids triggering the append-mode shortcut.

</details>

<details>
<summary>Observed bug in ITK's FetchContent build</summary>

When DCMTK is consumed in-scope via FetchContent (as ITK does), `DCMTKTargets.cmake` contained:

```
INTERFACE_LINK_LIBRARIES "DCMTK::ofstd;DCMTK::oflog;DCMTK::ITK::ITKZLIBModule"
```

The `DCMTK::` prefix was incorrectly prepended to the already-namespaced ITK codec targets. After this fix:

```
INTERFACE_LINK_LIBRARIES "DCMTK::ofstd;DCMTK::oflog;ITK::ITKZLIBModule"
```

See InsightSoftwareConsortium/ITK#6548 for context.

</details>